### PR TITLE
Add python exercises

### DIFF
--- a/week-1/1_2_python_exercises.ipynb
+++ b/week-1/1_2_python_exercises.ipynb
@@ -1,0 +1,985 @@
+{
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# UCLAIS DOXATHON Python Tutorial: Exercises"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Exercises\n",
+    "\n",
+    "- Numerics\n",
+    "- Shorthand assignment operators\n",
+    "- Functions\n",
+    "- Control flow (for and while loops)\n",
+    "- Recursive and non-recursive Fibonacci implementations\n",
+    "- Comprehensions\n",
+    "- min/max built-ins\n",
+    "- Dictionaries \n",
+    "- Sets\n",
+    "- Classes\n",
+    "\n",
+    "### Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import List"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 1: Numerics &ndash; the Modulo Operator"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Find the remainder when dividing 367 by 53"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: your code here\n",
+    "remainder = ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert remainder == 49"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 2: Numerics &ndash; Calculations\n",
+    "\n",
+    "> Compute the result of the following mathematical expression:\n",
+    "\n",
+    "$$\\text{result} = 9a^4 - \\dfrac{56b^2}{3c + 2} + 13$$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "a = 3\n",
+    "b = 3\n",
+    "c = 12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: your code here\n",
+    "result = ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert round(result) == 729"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 3: Shorthand Assignment Operators\n",
+    "\n",
+    "> Rewrite the following assignment statements using the shorthand assignment operators."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "variable = 17\n",
+    "\n",
+    "variable = variable + 5\n",
+    "variable = variable * 76\n",
+    "variable = variable - 7\n",
+    "variable = variable + 23\n",
+    "variable = variable / 12\n",
+    "variable = variable // 36"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert variable == 3"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 4: Functions"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Write a function `count_odd_numbers(numbers)` that takes in a list of integers and returns the number of odd numbers in the list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def count_odd_numbers(numbers: List[int]) -> int:\n",
+    "    count = 0\n",
+    "\n",
+    "    # TODO: your code here\n",
+    "\n",
+    "    return count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# These assertions will pass if you have implemented the function above correctly\n",
+    "assert count_odd_numbers([1, 2, 3, 4, 5, 6]) == 3\n",
+    "assert count_odd_numbers([1, 3, 5, 7]) == 4\n",
+    "assert count_odd_numbers([-2, 2, -10, 8]) == 0"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 5: Filtering Lists"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Implement the `bucket_list_filter` function which takes a list of activities (strings) and a list of completed activities as arguments. The function should return a list of bucket list activities that have been completed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# activities ticked off the bucket list\n",
+    "\n",
+    "COMPLETED_ACTIVITIES = [\"Skydiving\", \"Run a marathon\", \"Visit Japan\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def bucket_list_filter(activities: List[str], completed_activities: List[str]) -> List[str]:\n",
+    "    # TODO: your code here\n",
+    "\n",
+    "    pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "activities_to_check_1 = [\n",
+    "    \"Run a marathon\",\n",
+    "    \"Learn to draw\",\n",
+    "    \"Visit Japan\",\n",
+    "    \"Meet Miranda Hart\",\n",
+    "]\n",
+    "activities_done_1 = bucket_list_filter(activities_to_check_1, COMPLETED_ACTIVITIES)\n",
+    "assert set(activities_done_1) == {\"Run a marathon\", \"Visit Japan\"}\n",
+    "\n",
+    "activities_to_check_2 = [\n",
+    "    \"Fly a kite\",\n",
+    "    \"Ride a horse in Mongolia\",\n",
+    "    \"Learn how to make sushi\",\n",
+    "]\n",
+    "activities_done_2 = bucket_list_filter(activities_to_check_2, COMPLETED_ACTIVITIES)\n",
+    "assert activities_done_2 == []"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 6: Finding the Maximum Number in a List\n",
+    "\n",
+    "> Write a function to find the maximum number witin a list of numbers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_maximum_number(numbers):\n",
+    "    # TODO: your code here\n",
+    "\n",
+    "    pass"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Hint**: you could try using the built-in `max()` function, although how would you implement it yourself?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert find_maximum_number([5, 67, 89, -222, 10, 4583, 555.2]) == 4583\n",
+    "assert find_maximum_number([43, -55.2, 12, -3.2, 76, -90, 12, 23, 45]) == 76"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 7: Mystery Function\n",
+    "\n",
+    "> Defined below is the function `foo`. What do you think this function returns when given the dictionary `instagram_records`? Assign `guess` to what you think the result is, and make sure the data types match up!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def foo(dictionary):\n",
+    "    super_accounts = set()\n",
+    "\n",
+    "    for account, followers in dictionary.items():\n",
+    "        if followers > 5000000:\n",
+    "            super_accounts.add(account)\n",
+    "\n",
+    "    return super_accounts\n",
+    "\n",
+    "\n",
+    "instagram_records = {\n",
+    "    \"Kendall Jenner\": 278000000,\n",
+    "    \"SZA\": 15600000,\n",
+    "    \"Jerry Seinfeld\": 1300000,\n",
+    "    \"Miranda Hart\": 906000,\n",
+    "    \"The Economist\": 6100000,\n",
+    "    \"L'Impératrice\": 156000,\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# what do you think will be returned?\n",
+    "\n",
+    "guess = ..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert guess == foo(instagram_records)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> How could you rewrite the `xyz()` function using a set comprehension?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def foo_improved(dictionary):\n",
+    "    # TODO: your code here\n",
+    "\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "assert foo_improved(instagram_records) == foo(instagram_records)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 8: Control Flow (`if`, `for` and `while`)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert a list of numbers into a list of strings based on the following rules:\n",
+    "- if the number is greater than twenty, it is \"large\"\n",
+    "- if the number is less than twenty, it is \"small\"\n",
+    "- if the number is odd, it is \"odd\"\n",
+    "- if the number is even, it is \"even\"\n",
+    "\n",
+    "The number 23 is \"large odd\", whereas 4 is \"small even\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numbers = [5, 78, 3, 45, 67, 222, 34, 2, 44, 55, 90, 78]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: your code here\n",
+    "my_list = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert my_list == [\n",
+    "    \"small odd\",\n",
+    "    \"large even\",\n",
+    "    \"small odd\",\n",
+    "    \"large odd\",\n",
+    "    \"large odd\",\n",
+    "    \"large even\",\n",
+    "    \"large even\",\n",
+    "    \"small even\",\n",
+    "    \"large even\",\n",
+    "    \"large odd\",\n",
+    "    \"large even\",\n",
+    "    \"large even\",\n",
+    "]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 9: Fibonacci Sequence\n",
+    "\n",
+    "> Output the first 15 numbers in the Fibonacci sequence, using a `while` loop. To do this, complete the programme below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: complete this code\n",
+    "\n",
+    "series_length = 15\n",
+    "\n",
+    "a = 0\n",
+    "b = 1\n",
+    "sum = ...\n",
+    "count = ...\n",
+    "\n",
+    "while ...:\n",
+    "    pass"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Create a Fibonacci sequence again, but this time, recursively. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: complete this function\n",
+    "def fibonacci_sequence(number):\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "length = 13\n",
+    "\n",
+    "for i in ...:\n",
+    "    print(fibonacci_sequence(i), end=\" \")"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Which approach &ndash; iterative or recursive &ndash; would be preferable for this task?"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 10: List Comprehensions"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> You are given a list of floating-point numbers. Using a list comprehension, create a new list called `integers` containing only the whole numbers from the original list of numbers **as integers**."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numbers = [12.0, 3.4, 66.0, 7.8, 44.8, 9.1, 6.0, 3.0, 55.0, 89.23, 999.0, 76.0, 5.0, 43.0, 22.1, 44.0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: your code here\n",
+    "\n",
+    "integers = []"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert integers == [12, 66, 6, 3, 55, 999, 76, 5, 43, 44]"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Now, create a list (using a single list comprehension) that contains all the numbers from 1 to 1000 that have the digit 3 in them. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numbers_with_3 = []"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Dictionaries and Sets"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 11: Dictionaries\n",
+    "\n",
+    "> Create a dictionary `fruit_counts` that maps from fruit names to the number of times they appear in the list below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fruit = [\n",
+    "    \"apple\",\n",
+    "    \"blueberry\",\n",
+    "    \"cherry\",\n",
+    "    \"apple\",\n",
+    "    \"pear\",\n",
+    "    \"guava\",\n",
+    "    \"pear\",\n",
+    "    \"blueberry\",\n",
+    "    \"guava\",\n",
+    "    \"blueberry\",\n",
+    "    \"apple\",\n",
+    "    \"cherry\",\n",
+    "    \"watermelon\",\n",
+    "    \"cherry\",\n",
+    "    \"cherry\",\n",
+    "    \"apple\",\n",
+    "    \"blueberry\",\n",
+    "    \"cherry\",\n",
+    "    \"pear\",\n",
+    "    \"melon\",\n",
+    "    \"blueberry\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fruit_counts = {}\n",
+    "\n",
+    "# TODO: your code here"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Your output should match what you see below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Counter({'apple': 4,\n",
+       "         'blueberry': 5,\n",
+       "         'cherry': 5,\n",
+       "         'pear': 3,\n",
+       "         'guava': 2,\n",
+       "         'watermelon': 1,\n",
+       "         'melon': 1})"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from collections import Counter\n",
+    "\n",
+    "Counter(fruit)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 12: String Parsing & Dictionaries\n",
+    "\n",
+    "> From the string of matches and results below, create a dictionary where each key is a country, and each value is the number of goals scored per country. For example, \"France,England,5,2\" means that France scored 5 goals and England scored 2 goals. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matches = \"\"\"France,England,5,2\n",
+    "Spain,Poland,3,2\n",
+    "France,Italy,2,0\n",
+    "England,Spain,1,3\n",
+    "Germany,England,1,1\"\"\"\n",
+    "\n",
+    "scores = {}\n",
+    "\n",
+    "for line in matches.split(\"\\n\"):\n",
+    "    # TODO: your code here\n",
+    "\n",
+    "    pass\n",
+    "\n",
+    "# steps to solve this exercise:\n",
+    "\n",
+    "# step 1: split the string per line, and then within each line, per country and score\n",
+    "# step 2: check if the countries are already in the scores dictionary; if not, add them to it\n",
+    "# step 3: for each country, add the goals recorded in that line\n",
+    "\n",
+    "# this process must be iterative - use a for loop"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "correct_scores = {\n",
+    "    \"France\": 7,\n",
+    "    \"England\": 4,\n",
+    "    \"Spain\": 6,\n",
+    "    \"Poland\": 2,\n",
+    "    \"Italy\": 0,\n",
+    "    \"Germany\": 1,\n",
+    "}\n",
+    "\n",
+    "assert scores == correct_scores"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 13: Sets\n",
+    "\n",
+    "Sets have some interesting properties. Each element within a set is unique, and two different sets can be compared to find where they overlap, and where they do not.\n",
+    "\n",
+    "Sets can be compared using:\n",
+    "- `intersection()` or `&`: returns the intersection between two sets\n",
+    "- `union()` or `|`: returns the union of two sets\n",
+    "- `difference()` or `-`: returns the difference between two sets\n",
+    "\n",
+    "Check out how they work below!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{8}\n",
+      "{8}\n",
+      "{3, 4, 5, 6, 7, 8, 56}\n",
+      "{3, 4, 5, 6, 7, 8, 56}\n",
+      "{56, 3, 7}\n",
+      "{4, 5, 6}\n",
+      "{3, 4, 5, 6, 7, 56}\n"
+     ]
+    }
+   ],
+   "source": [
+    "set1 = {3, 56, 7, 8}\n",
+    "set2 = {4, 5, 6, 8}\n",
+    "\n",
+    "print(set1 & set2)\n",
+    "print(set2 & set1)\n",
+    "\n",
+    "print(set1 | set2)\n",
+    "print(set2 | set1)\n",
+    "\n",
+    "print(set1 - set2)\n",
+    "print(set2 - set1)\n",
+    "\n",
+    "# what is this operation?\n",
+    "print(set1 ^ set2)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Two sets of genes are being studied for their involvement in Schizophrenia and Bipolar disorder. Both bipolar disorder are known to cause psychosis (to different extents), and some researchers want to see if there is any possible overlap between the two disorders from a genetic perspective. \n",
+    ">\n",
+    "> Help the scientists identify which genes are found to be involved in both disorders. \n",
+    "\n",
+    "Sources: \n",
+    "- [Kegg Genes Database](https://www.genome.jp/kegg/genes.html)\n",
+    "- [Specific genes involved in schizophrenia identified for the first time](https://www.ucl.ac.uk/news/2022/apr/specific-genes-involved-schizophrenia-identified-first-time)\n",
+    "- [Genetics of bipolar disorder](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3966627/)\n",
+    "\n",
+    "**Warning**: the list below is a compilation of a couple different genes. The mechanisms of these disorders remain unclear, and it is not known how involved they may or may not be. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "risk_genes_schizophrenia = {\"AKAP11\", \"NRXN1\", \"SHANK3\", \"AKT1\", \"PRODH\", \"DRD3\"}\n",
+    "risk_genes_bipolar = {\"AKAP11\", \"XBP1\", \"CACNA1C\", \"ODZ4\", \"NCAN\"}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Which genes are found in both sets?\n",
+    "\n",
+    "genes_in_both = ..."
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 14: `min()` and `max()`"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> You have been asked to process the data in a dictionary containing Wikipedia article names. You need to return the article with the longest introductory paragraph. \n",
+    "\n",
+    "**Hint**: use the `key` parameter. It may also be useful to create your own function (or use a lambda function if you're willing to research it and experiment)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wiki_articles = {\n",
+    "    \"Wikipedia\": \"Wikipedia[note 3] is a multilingual free online encyclopedia written and maintained by a community of volunteers, known as Wikipedians, through open collaboration and using a wiki-based editing system called MediaWiki. Wikipedia is the largest and most-read reference work in history.[3] It is consistently one of the 10 most popular websites ranked by Similarweb and formerly Alexa; as of 2022, Wikipedia was ranked the 5th most popular site in the world.[4] It is hosted by the Wikimedia Foundation, an American non-profit organization funded mainly through donations.[5]\",\n",
+    "    \"Portugal\": \"Portugal (Portuguese pronunciation: [puɾtuˈɣal]), officially the Portuguese Republic (Portuguese: República Portuguesa [ʁɛˈpuβlikɐ puɾtuˈɣezɐ]),[note 4] is a country located on the Iberian Peninsula, in southwestern Europe, and whose territory also includes the Atlantic archipelagos of the Azores and Madeira. It features the westernmost point in continental Europe, and its Iberian portion is bordered to the west and south by the Atlantic Ocean and to the north and east by Spain, the sole country to have a land border with Portugal. Its two archipelagos form two autonomous regions with their own regional governments. Lisbon is the capital and largest city by population.\",\n",
+    "    \"Frank Sinatra\": \"Francis Albert Sinatra (/sɪˈnɑːtrə/; December 12, 1915 – May 14, 1998) was an American singer and actor. Nicknamed the 'Chairman of the Board' and later called \\\"Ol' Blue Eyes\\\", Sinatra was one of the most popular entertainers of the 1940s, 1950s, and 1960s. He is among the world's best-selling music artists with an estimated 150 million record sales.[1][2]\",\n",
+    "    \"Growth Hormone-Releasing Hormone\": \"Growth hormone-releasing hormone (GHRH), also known as somatocrinin or by several other names in its endogenous forms and as somatorelin (INN) in its pharmaceutical form, is a releasing hormone of growth hormone (GH). It is a 44[1]-amino acid peptide hormone produced in the arcuate nucleus of the hypothalamus.\",\n",
+    "    \"Beyoncé\": 'Beyoncé Giselle Knowles-Carter (/biˈɒnseɪ/ (listen) bee-ON-say;[4] born September 4, 1981)[5] is an American singer, songwriter, actress, and dancer. Beyoncé has been noted for her boundary-pushing artistry and her vocal ability.[6] Her success has made her a cultural icon and earned her the nickname \"Queen Bey\".[7]',\n",
+    "    \"Everything Everywhere All at Once\": 'Everything Everywhere All at Once is a 2022 American absurdist comedy-drama film written and directed by Daniel Kwan and Daniel Scheinert (collectively known as Daniels), who produced it with Anthony and Joe Russo. The plot centers on a Chinese-American immigrant played by Michelle Yeoh who, while being audited by the IRS, discovers that she must connect with parallel universe versions of herself to prevent a powerful being from destroying the multiverse. Stephanie Hsu, Ke Huy Quan, Jenny Slate, Harry Shum Jr., James Hong, and Jamie Lee Curtis appear in supporting roles. The New York Times called the film a \"swirl of genre anarchy\" with elements of surreal comedy, science fiction, fantasy, martial arts films, and animation.',\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "longest_intro_article = max(TODO)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> Now, using the same dictionary of Wikipedia articles, find the article with the smallest incidence of the letter \"a\" in the introductory paragraph (irrespective of capitalisation).\n",
+    "\n",
+    "**Hint**: the `key` parameter might help here again!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def incidence_of_a(TODO):\n",
+    "    pass\n",
+    "\n",
+    "\n",
+    "smallest_incidence_of_a = min(wiki_articles, key=...)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert smallest_incidence_of_a == \"Beyoncé\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 15: Classes"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> You have been tasked with creating a class to create animal characters for a video game. Each animal must have a name, an age, a weight, a super power, and a fatal flaw. Optionally, each animal can also have a short description that explains why it is unique. \n",
+    ">\n",
+    "> Create this class by completing the following code. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Animal:\n",
+    "    def __init__(self, name, age, weight, super_power, fatal_flaw):\n",
+    "        pass\n",
+    "\n",
+    "    def __str__(self):\n",
+    "        return f\"Hi, my name is {...}. I am {...} years old. My super power is {...}. My fatal flaw is {...}\"\n",
+    "\n",
+    "    def get_description(self, characteristics):\n",
+    "        return \"Yay! Thanks for the description.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rhino = Animal(\"Rhino\", 3, 43, \"Charge\", \"Butterflies\")\n",
+    "\n",
+    "assert (\n",
+    "    rhino\n",
+    "    == \"Hi, my name is Rhino. I am 3 years old. My super power is Charge. My fatal flaw is Butterflies.\"\n",
+    ")\n",
+    "\n",
+    "print(rhino.get_description(\"The kindest little thing in the world.\"))\n",
+    "\n",
+    "assert rhino.characteristics == \"The kindest little thing in the world.\""
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now, go back to where you define your class, and create some more functions. For example, the animal characters could have fighting modes, or could say things like \"It's a beautiful day in paradise\". \n",
+    "\n",
+    "Basically, have fun with it, test it out, and enjoy creating a world of your own. "
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Exercise 16: Tetris\n",
+    "\n",
+    "> Congratulations &ndash; you may be at the start of your journey through the world of Python, but you have reached the end of the exercises in this notebook!\n",
+    "> \n",
+    "> Your next challenge is to make a simple bot to play [Tetris on DOXA](https://doxaai.com/competition/tetris). Good luck!"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.1"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/week-1/1_2_python_exercises.ipynb
+++ b/week-1/1_2_python_exercises.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# UCLAIS DOXATHON Python Tutorial: Exercises"
+    "# UCLAIS Introduction to Python: Exercises"
    ]
   },
   {
@@ -947,17 +947,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Exercise 16: Tetris\n",
+    "### Exercise 16: Explore\n",
     "\n",
     "> Congratulations &ndash; you may be at the start of your journey through the world of Python, but you have reached the end of the exercises in this notebook!\n",
     "> \n",
-    "> Your next challenge is to make a simple bot to play [Tetris on DOXA](https://doxaai.com/competition/tetris). Good luck!"
+    "> Feel free to go on and explore the internet for *awesome* Python projects, this might be a great place to start: https://github.com/vinta/awesome-python"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -971,9 +971,8 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.1"
+   "version": "3.9.12"
   },
-  "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
     "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
@@ -981,5 +980,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR adds a single file: week-1/1_2_python_exercises.ipynb containing the exercises taken from https://github.com/UCLAIS/doxathon-2023-python-tutorial/blob/main/Python%20Exercises.ipynb repo and cleaned for more general use case.

The file has been renamed from the original, and also references to Tetris exercises have been removed.